### PR TITLE
Use native functions instead of boxed closures for field accessors

### DIFF
--- a/chert_accessor/src/lib.rs
+++ b/chert_accessor/src/lib.rs
@@ -3,46 +3,46 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 
 pub enum ChertField<T> {
-    Boolean(Box<dyn Fn(&T) -> &bool>),
-    Cidr(Box<dyn Fn(&T) -> &IpCidr>),
-    Int64(Box<dyn Fn(&T) -> &i64>),
-    Ip(Box<dyn Fn(&T) -> &IpAddr>),
-    String(Box<dyn Fn(&T) -> &String>),
-    Uint64(Box<dyn Fn(&T) -> &u64>),
+    Boolean(fn(&T) -> &bool),
+    Cidr(fn(&T) -> &IpCidr),
+    Int64(fn(&T) -> &i64),
+    Ip(fn(&T) -> &IpAddr),
+    String(fn(&T) -> &String),
+    Uint64(fn(&T) -> &u64),
 }
 
-impl<T> From<Box<dyn Fn(&T) -> &String>> for ChertField<T> {
-    fn from(field: Box<dyn Fn(&T) -> &String>) -> Self {
+impl<T> From<fn(&T) -> &String> for ChertField<T> {
+    fn from(field: fn(&T) -> &String) -> Self {
         Self::String(field)
     }
 }
 
-impl<T> From<Box<dyn Fn(&T) -> &u64>> for ChertField<T> {
-    fn from(field: Box<dyn Fn(&T) -> &u64>) -> Self {
+impl<T> From<fn(&T) -> &u64> for ChertField<T> {
+    fn from(field: fn(&T) -> &u64) -> Self {
         Self::Uint64(field)
     }
 }
 
-impl<T> From<Box<dyn Fn(&T) -> &i64>> for ChertField<T> {
-    fn from(field: Box<dyn Fn(&T) -> &i64>) -> Self {
+impl<T> From<fn(&T) -> &i64> for ChertField<T> {
+    fn from(field: fn(&T) -> &i64) -> Self {
         Self::Int64(field)
     }
 }
 
-impl<T> From<Box<dyn Fn(&T) -> &bool>> for ChertField<T> {
-    fn from(field: Box<dyn Fn(&T) -> &bool>) -> Self {
+impl<T> From<fn(&T) -> &bool> for ChertField<T> {
+    fn from(field: fn(&T) -> &bool) -> Self {
         Self::Boolean(field)
     }
 }
 
-impl<T> From<Box<dyn Fn(&T) -> &IpAddr>> for ChertField<T> {
-    fn from(field: Box<dyn Fn(&T) -> &IpAddr>) -> Self {
+impl<T> From<fn(&T) -> &IpAddr> for ChertField<T> {
+    fn from(field: fn(&T) -> &IpAddr) -> Self {
         Self::Ip(field)
     }
 }
 
-impl<T> From<Box<dyn Fn(&T) -> &IpCidr>> for ChertField<T> {
-    fn from(field: Box<dyn Fn(&T) -> &IpCidr>) -> Self {
+impl<T> From<fn(&T) -> &IpCidr> for ChertField<T> {
+    fn from(field: fn(&T) -> &IpCidr) -> Self {
         Self::Cidr(field)
     }
 }

--- a/chert_derive/src/lib.rs
+++ b/chert_derive/src/lib.rs
@@ -1,9 +1,7 @@
 use proc_macro::TokenStream;
 use proc_macro2::Ident;
 use quote::quote;
-use syn::{
-    parse_macro_input, Data::Struct, DataStruct, DeriveInput, Fields::Named, FieldsNamed,
-};
+use syn::{parse_macro_input, Data::Struct, DataStruct, DeriveInput, Fields::Named, FieldsNamed};
 
 #[proc_macro_derive(ChertStruct)]
 pub fn derive(input: TokenStream) -> TokenStream {
@@ -12,7 +10,8 @@ pub fn derive(input: TokenStream) -> TokenStream {
     let Struct(DataStruct {
         fields: Named(FieldsNamed { ref named, .. }),
         ..
-    }) = data else {
+    }) = data
+    else {
         panic!("must be a struct with named fields");
     };
 
@@ -22,8 +21,8 @@ pub fn derive(input: TokenStream) -> TokenStream {
     let mut accessor_functions = Vec::new();
 
     for (i, t) in named
-            .iter()
-            .filter_map(|f| f.ident.as_ref().map(|i| (i, &f.ty)))
+        .iter()
+        .filter_map(|f| f.ident.as_ref().map(|i| (i, &f.ty)))
     {
         let accessor_name = Ident::new(
             &format!("get_{}", i.to_string().to_ascii_lowercase()),

--- a/examples/eval/src/main.rs
+++ b/examples/eval/src/main.rs
@@ -9,7 +9,9 @@ struct Arguments {
 }
 
 #[derive(Clone, Debug, ChertStruct)]
-struct Variables {}
+struct Variables {
+    _a: i64,
+}
 
 fn main() {
     let args = Arguments::parse();
@@ -19,7 +21,7 @@ fn main() {
     if let chert::parse::nodes::Node::Boolean(node) = node {
         println!("{node:?}");
         let engine = chert::compile::compile(Vec::from([(0, node)]));
-        let results = engine.eval(&Variables {});
+        let results = engine.eval(&Variables { _a: 0 });
         println!("{results:?}");
     } else {
         panic!("expression must result in a boolean");


### PR DESCRIPTION
Removes a level of indirection and simplifies the code