### PR TITLE
Allow accessing fields via AsRef

### DIFF
--- a/chert_accessor/src/lib.rs
+++ b/chert_accessor/src/lib.rs
@@ -27,7 +27,7 @@ macro_rules! simple_field_type {
                 ChertField::$variant(field)
             }
         }
-    }
+    };
 }
 
 simple_field_type!(bool, Boolean);

--- a/chert_accessor/src/lib.rs
+++ b/chert_accessor/src/lib.rs
@@ -14,7 +14,7 @@ pub enum ChertField<T> {
     Cidr(fn(&T) -> &IpCidr),
     Int64(fn(&T) -> &i64),
     Ip(fn(&T) -> &IpAddr),
-    String(fn(&T) -> &String),
+    String(fn(&T) -> &str),
     Uint64(fn(&T) -> &u64),
     Regex(fn(&T) -> &Regex),
 }
@@ -35,8 +35,15 @@ simple_field_type!(i64, Int64);
 simple_field_type!(u64, Uint64);
 simple_field_type!(IpAddr, Ip);
 simple_field_type!(IpCidr, Cidr);
-simple_field_type!(String, String);
+simple_field_type!(str, String);
 simple_field_type!(Regex, Regex);
+
+impl ChertFieldType for String {
+    type AccessedAs = str;
+    fn from_field<T>(field: fn(&T) -> &Self::AccessedAs) -> ChertField<T> {
+        ChertField::String(field)
+    }
+}
 
 impl<T> From<fn(&T) -> &Regex> for ChertField<T> {
     fn from(field: fn(&T) -> &Regex) -> Self {

--- a/chert_derive/src/lib.rs
+++ b/chert_derive/src/lib.rs
@@ -1,14 +1,37 @@
 use proc_macro::TokenStream;
 use proc_macro2::Ident;
-use quote::quote;
-use syn::{parse_macro_input, Data::Struct, DataStruct, DeriveInput, Fields::Named, FieldsNamed};
+use quote::{quote, ToTokens};
+use syn::{parse::Parse, parse_macro_input, Data::Struct, DataStruct, DeriveInput, Fields::Named, FieldsNamed, Token, Type};
 
-#[proc_macro_derive(ChertStruct)]
+mod kw {
+    syn::custom_keyword!(as_ref);
+}
+
+enum ChertAttribute {
+    AsRef {
+        _as_ref: kw::as_ref,
+        _equals: Token![=],
+        as_type: Type,
+    }
+}
+
+impl Parse for ChertAttribute {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(kw::as_ref) {
+            Ok(Self::AsRef { _as_ref: input.parse()?, _equals: input.parse()?, as_type: input.parse()? })
+        } else {
+            Err(lookahead.error())
+        }
+    }
+}
+
+#[proc_macro_derive(ChertStruct, attributes(chert))]
 pub fn derive(input: TokenStream) -> TokenStream {
-    let DeriveInput { ident, data, .. } = parse_macro_input!(input as DeriveInput);
+    let DeriveInput { ident: struct_name, data, .. } = parse_macro_input!(input as DeriveInput);
 
     let Struct(DataStruct {
-        fields: Named(FieldsNamed { ref named, .. }),
+        fields: Named(FieldsNamed { named: ref named_fields, .. }),
         ..
     }) = data
     else {
@@ -18,35 +41,58 @@ pub fn derive(input: TokenStream) -> TokenStream {
     let mut fields = Vec::new();
     let mut accessor_functions = Vec::new();
 
-    for (i, t) in named
-        .iter()
-        .filter_map(|f| f.ident.as_ref().map(|i| (i, &f.ty)))
+    for field in named_fields.iter()
     {
+        let Some(field_name) = &field.ident else { continue };
+        let mut field_type = field.ty.clone();
+        let mut use_as_ref = false;
+
+        for attr in &field.attrs {
+            if attr.path().is_ident("chert") {
+                let Ok(chert_attr)  = attr.parse_args::<ChertAttribute>() else { panic!("Invalid chert attribute: {}", attr.to_token_stream()) };
+
+                let ChertAttribute::AsRef { as_type, .. } = chert_attr;
+                field_type = as_type;
+                use_as_ref = true;
+            }
+        }
+
         let accessor_name = Ident::new(
-            &format!("_chert_get_{}", i.to_string().to_ascii_lowercase()),
-            i.span(),
+            &format!("_chert_get_{}", field_name.to_string().to_ascii_lowercase()),
+            field_name.span(),
         );
 
-        let ident_str = i.to_string();
+        let ident_str = field_name.to_string();
 
         fields.push(quote! {
-            (#ident_str, <#t as chert::ChertFieldType>::from_field(Self::#accessor_name))
+            (#ident_str, <#field_type as chert::ChertFieldType>::from_field(Self::#accessor_name))
         });
 
-        accessor_functions.push(quote! {
-            #[allow(non_snake_case)]
-            fn #accessor_name(object: &#ident) -> &<#t as chert::ChertFieldType>::AccessedAs {
-                &object.#i
-            }
-        });
+        if use_as_ref {
+            accessor_functions.push(quote! {
+                #[allow(non_snake_case)]
+                fn #accessor_name(object: &#struct_name) -> &<#field_type as chert::ChertFieldType>::AccessedAs {
+                    use std::convert::AsRef;
+                    object.#field_name.as_ref()
+                }
+            });
+
+        } else {
+            accessor_functions.push(quote! {
+                #[allow(non_snake_case)]
+                fn #accessor_name(object: &#struct_name) -> &<#field_type as chert::ChertFieldType>::AccessedAs {
+                    &object.#field_name
+                }
+            });
+        }
     }
 
     quote! {
-        impl #ident {
+        impl #struct_name {
             #(#accessor_functions)*
         }
 
-        impl chert::ChertStructTrait for #ident {
+        impl chert::ChertStructTrait for #struct_name {
             fn fields() -> std::collections::HashMap<String, (usize, chert::ChertField<Self>)> {
                 use std::collections::HashMap;
                 use chert::ChertField;

--- a/chert_derive/src/lib.rs
+++ b/chert_derive/src/lib.rs
@@ -30,7 +30,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
         let ident_str = i.to_string();
 
         fields.push(quote! {
-            (#ident_str, <chert::ChertField::<Self> as From<fn(&#ident) -> &#t>>::from(Self::#accessor_name))
+            (#ident_str, <#t as chert::ChertFieldType>::from_field(Self::#accessor_name))
         });
 
         accessor_functions.push(quote! {

--- a/chert_derive/src/lib.rs
+++ b/chert_derive/src/lib.rs
@@ -35,7 +35,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
         accessor_functions.push(quote! {
             #[allow(non_snake_case)]
-            fn #accessor_name(object: &#ident) -> &#t {
+            fn #accessor_name(object: &#ident) -> &<#t as chert::ChertFieldType>::AccessedAs {
                 &object.#i
             }
         });

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -416,7 +416,9 @@ impl<T, H: Hash> Engine<T, H> {
                 ChertField::Cidr(field) => dynamics.cidr[*index] = *(*field)(variables),
                 ChertField::Int64(field) => dynamics.int64[*index] = *(*field)(variables),
                 ChertField::Ip(field) => dynamics.ip[*index] = *(*field)(variables),
-                ChertField::String(field) => dynamics.string[*index] = (*field)(variables).to_owned(),
+                ChertField::String(field) => {
+                    dynamics.string[*index] = (*field)(variables).to_owned()
+                }
                 ChertField::Uint64(field) => dynamics.uint64[*index] = *(*field)(variables),
                 ChertField::Regex(field) => dynamics.regex[*index] = (*field)(variables).clone(),
             };

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -416,7 +416,7 @@ impl<T, H: Hash> Engine<T, H> {
                 ChertField::Cidr(field) => dynamics.cidr[*index] = *(*field)(variables),
                 ChertField::Int64(field) => dynamics.int64[*index] = *(*field)(variables),
                 ChertField::Ip(field) => dynamics.ip[*index] = *(*field)(variables),
-                ChertField::String(field) => dynamics.string[*index] = (*field)(variables).clone(),
+                ChertField::String(field) => dynamics.string[*index] = (*field)(variables).to_owned(),
                 ChertField::Uint64(field) => dynamics.uint64[*index] = *(*field)(variables),
                 ChertField::Regex(field) => dynamics.regex[*index] = (*field)(variables).clone(),
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ pub mod lex;
 pub mod parse;
 
 pub use crate::compile::{compile, Engine};
-pub use chert_accessor::{ChertField, ChertStructTrait};
+pub use chert_accessor::{ChertField, ChertFieldType, ChertStructTrait};
 pub use chert_derive::ChertStruct;
 
 #[derive(Debug)]


### PR DESCRIPTION
This adds the 'chert' helper attribute within #[derive(ChertStruct)], which looks something like:

```
#[derive(Clone, Debug, ChertStruct)]
struct Variables {
    #[chert(as_ref=str)]
    s: MyString,
    i: u64,
    ip: IpAddr,
}
```
