### PR TITLE
Let compile operate on node references

### DIFF
--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -492,23 +492,22 @@ impl<T, H: Hash> Engine<T, H> {
     }
 }
 
-
 pub fn compile<T, H, I>(expressions: I) -> Engine<T, H>
-    where T: ChertStructTrait,
-          H: Hash,
-          I: IntoIterator<Item = (H, Ast<T, NodeBoolean>)>
+where
+    T: ChertStructTrait,
+    H: Hash,
+    I: IntoIterator<Item = (H, Ast<T, NodeBoolean>)>,
 {
-    let expressions = expressions
-        .into_iter()
-        .map(|(id, ast)| (id, ast.root));
+    let expressions = expressions.into_iter().map(|(id, ast)| (id, ast.root));
     compile_unsafe(expressions)
 }
 
 pub fn compile_unsafe<T, H, N, I>(expressions: I) -> Engine<T, H>
-    where T: ChertStructTrait,
-          H: Hash,
-          N: Borrow<NodeBoolean>,
-          I: IntoIterator<Item = (H, N)>
+where
+    T: ChertStructTrait,
+    H: Hash,
+    N: Borrow<NodeBoolean>,
+    I: IntoIterator<Item = (H, N)>,
 {
     let fields = T::fields();
     let mut constants = Scratch::new();

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -215,10 +215,6 @@ impl<T, R> Ast<T, R> {
     pub fn get_root(&self) -> &R {
         &self.root
     }
-
-    pub(crate) unsafe fn new(root: R) -> Ast<T, R> {
-        Ast { root, _type: None }
-    }
 }
 
 pub fn parse<T: ChertStructTrait>(

--- a/tests/only-slightly-unsafe.rs
+++ b/tests/only-slightly-unsafe.rs
@@ -9,7 +9,7 @@ fn test_serialize() {
     let ast = serde_json::to_string_pretty(&ast.get_root()).unwrap();
 
     let ast: chert::NodeBoolean = serde_json::from_str(&ast).unwrap();
-    let engine = unsafe { chert::compile_unsafe::<Variables, _>(Vec::from([(0, ast)])) };
+    let engine = unsafe { chert::compile_unsafe::<Variables, _, _, _>(Vec::from([(0, ast)])) };
     engine.eval(&Variables { a: 1 });
 }
 
@@ -24,6 +24,6 @@ fn test_serialize_with_id() {
     let ast = serde_json::to_string_pretty(&Vec::from([(0, ast.get_root())])).unwrap();
 
     let asts: Vec<(i32, chert::NodeBoolean)> = serde_json::from_str(&ast).unwrap();
-    let engine = unsafe { chert::compile_unsafe::<Variables, _>(asts) };
+    let engine = unsafe { chert::compile_unsafe::<Variables, _, _, _>(asts) };
     engine.eval(&Variables { a: 1 });
 }


### PR DESCRIPTION
This allows `compile_unsafe` to take an iterator over (H, &NodeBoolean) or (H, NodeBoolean) depending what's available, which avoids unnecessarily cloning all the expressions when recompiling because one was added or removed.

In order to do this I had to swap `compile` and `compile_unsafe` so that an Ast gets unpacked into the NodeBoolean it contains, rather than constructing a new Ast around something which is no longer owned.